### PR TITLE
refactor: remove sector id and use u64 directly

### DIFF
--- a/src/cluster_heap/allocation_bitmap/locator.rs
+++ b/src/cluster_heap/allocation_bitmap/locator.rs
@@ -1,6 +1,6 @@
 use super::meta::Meta;
 use crate::io::Block;
-use crate::types::{ClusterID, SectorID};
+use crate::types::{ClusterID, Sector};
 
 pub struct InSector(u32);
 
@@ -14,13 +14,13 @@ impl InSector {
 #[display("{cluster}")]
 pub struct Locator {
     pub meta: Meta,
-    pub base: SectorID,
+    pub base: Sector,
     pub cluster: ClusterID,
 }
 
 impl Locator {
-    pub fn sector(&self) -> SectorID {
-        self.base + self.cluster.offset() / 8 / self.meta.sector_size()
+    pub fn sector(&self) -> u64 {
+        self.base + (self.cluster.offset() / self.meta.sector_size()) as u64
     }
 
     pub fn in_sector(&self) -> InSector {
@@ -28,16 +28,16 @@ impl Locator {
     }
 
     pub fn out_of_range(&self) -> bool {
-        self.cluster.offset() / 8 >= self.meta.size
+        self.cluster.offset() >= self.meta.size
     }
 
     pub fn bit(&self) -> usize {
-        (self.cluster.offset() % 8) as usize
+        self.cluster.bit() as usize
     }
 
-    pub fn bits(&self, block: &[Block]) -> u8 {
+    pub fn bits(&self, blocks: &[Block]) -> u8 {
         let index = self.in_sector().byte() as usize;
-        block[index / 512][index % 512]
+        crate::io::flatten(blocks)[index]
     }
 
     pub fn is_clear(&self, block: &[Block]) -> Option<u8> {

--- a/src/cluster_heap/allocation_bitmap/meta.rs
+++ b/src/cluster_heap/allocation_bitmap/meta.rs
@@ -5,7 +5,6 @@ use crate::error::Error;
 use crate::io::{self, Block, Wrap};
 use crate::region::boot::BootSector;
 use crate::sync::Share;
-use crate::types::SectorID;
 
 #[derive(Copy, Clone)]
 pub struct Meta {
@@ -24,7 +23,7 @@ impl Meta {
         S: Share<Target = IO>,
     {
         let mut io = io.acquire().await.wrap();
-        let blocks = io.read(SectorID::BOOT).await?;
+        let blocks = io.read(crate::BOOT_SECTOR).await?;
         let boot_sector: &BootSector = unsafe { transmute(&blocks[0]) };
         let sector_size_shift = boot_sector.bytes_per_sector_shift;
         let num_clusters = boot_sector.cluster_count.to_ne();

--- a/src/cluster_heap/allocation_bitmap/mod.rs
+++ b/src/cluster_heap/allocation_bitmap/mod.rs
@@ -2,8 +2,8 @@ pub(crate) mod clusters;
 mod locator;
 pub(crate) mod meta;
 
-use core::mem::{size_of, transmute};
-use core::ops::{BitXor, Deref, Sub};
+use core::mem::size_of;
+use core::ops::Deref;
 
 use memoffset::offset_of;
 
@@ -13,13 +13,11 @@ use crate::io::{self, BLOCK_SIZE, Block, Wrap};
 use crate::region::boot::BootSector;
 use crate::region::fat::Entry;
 use crate::sync::Share;
-use crate::types::{ClusterID, SectorID};
+use crate::types::{ClusterID, Sector};
 
 pub use clusters::Clusters;
 use locator::Locator;
 pub use meta::Meta;
-
-const BITMAP_SIZE: usize = BLOCK_SIZE / size_of::<usize>();
 
 fn lsb(bits: u8) -> u8 {
     bits ^ ((bits - 1) & bits)
@@ -29,10 +27,16 @@ fn bit_to_offset(bit: u8) -> u8 {
     u8::trailing_zeros(bit) as u8
 }
 
+fn to_bitmap(blocks: &[Block]) -> &[usize] {
+    const NUM_USIZE: usize = BLOCK_SIZE / size_of::<usize>();
+    let slice: &[[usize; NUM_USIZE]] = unsafe { core::mem::transmute(blocks) };
+    unsafe { core::slice::from_raw_parts(&slice[0][0], slice.len() * NUM_USIZE) }
+}
+
 #[derive(Clone)]
 pub struct DumbAllocator<IO> {
     io: IO,
-    base: SectorID,
+    base: Sector,
     fat: FAT,
     cursor: ClusterID,
     meta: Meta,
@@ -49,22 +53,20 @@ where
         let mut num_inuse = 0;
         let mut io = self.io.acquire().await.wrap();
         for sector_offset in 0..self.meta.num_sectors() {
-            let sector = io.read(self.base + sector_offset).await?;
-            let blocks: &[[usize; BITMAP_SIZE]] = unsafe { transmute(&*sector) };
-            for i in 0..(sector_size as usize / BLOCK_SIZE) {
-                let sum = blocks[i].iter().map(|bits| bits.count_ones()).sum::<u32>();
-                if !self.cursor.valid() && sum < sector_size {
-                    let num_clusters = sector_offset * sector_size + (i * BLOCK_SIZE) as u32;
-                    self.cursor = ClusterID::FIRST + num_clusters;
+            let blocks = io.read(self.base + sector_offset as u64).await?;
+            for (i, &bits) in to_bitmap(&blocks).iter().enumerate() {
+                num_inuse += bits.count_ones();
+                if !self.cursor.valid() && bits != usize::MAX {
+                    let offset = sector_offset * sector_size + (i * size_of::<usize>()) as u32;
+                    self.cursor = ClusterID::FIRST + offset * 8;
                 }
-                num_inuse += sum;
             }
         }
         self.num_inuse = num_inuse;
         Ok(())
     }
 
-    pub(crate) async fn new(io: S, base: SectorID, fat: FAT, meta: Meta) -> Self {
+    pub(crate) async fn new(io: S, base: Sector, fat: FAT, meta: Meta) -> Self {
         Self { io, base, fat, meta, cursor: ClusterID::FIRST, num_inuse: meta.estimate_num_inuse() }
     }
 
@@ -82,15 +84,15 @@ where
 
     async fn find_available(&mut self) -> Result<(u32, u8), Error<E>> {
         let mut io = self.io.acquire().await.wrap();
-        let mut sector_id = self.base + self.cursor.offset() / self.meta.sector_size();
-        let mut sector = io.read(sector_id).await?;
+        let mut sector = self.base + (self.cursor.offset() / self.meta.sector_size()) as u64;
+        let mut blocks = io.read(sector).await?;
         for i in self.cursor.offset()..self.meta.size {
             if i != self.cursor.offset() && i % self.meta.sector_size() == 0 {
-                sector_id += 1u64;
-                sector = io.read(sector_id).await?;
+                sector += 1u64;
+                blocks = io.read(sector).await?;
             }
             let index = (i % self.meta.sector_size()) as usize;
-            let bits = sector[index / 512][index % 512];
+            let bits = blocks[index / 512][index % 512];
             if bits != u8::MAX {
                 return Ok((i, bits));
             }
@@ -110,7 +112,7 @@ where
         }
         self.meta.percent_inuse = percent_inuse as u8;
         let bytes: [u8; 1] = [self.meta.percent_inuse];
-        self.io.acquire().await.wrap().write(SectorID::BOOT, offset, &bytes).await
+        self.io.acquire().await.wrap().write(crate::BOOT_SECTOR, offset, &bytes).await
     }
 
     pub async fn allocate(
@@ -119,26 +121,26 @@ where
         if self.num_inuse + size > self.meta.num_clusters {
             return Err(AllocationError::NoMoreCluster.into());
         }
-        let mut loc = self.locator(nofrag.unwrap_or(self.cursor));
+        let mut locator = self.locator(nofrag.unwrap_or(self.cursor));
         let mut bits = 0xFFu8;
 
-        if let Some(byte) = self.is_available(loc.advance()).await? {
+        if let Some(byte) = self.is_available(locator.advance()).await? {
             bits = byte;
         } else if nofrag.is_some() {
             return Err(AllocationError::Fragment.into());
         }
         if bits == 0xFF {
             let (byte_offset, bits) = self.find_available().await?;
-            loc.cluster = ClusterID::FIRST + byte_offset * 8 + bit_to_offset(lsb(!bits));
+            locator.cluster = ClusterID::FIRST + byte_offset * 8 + bit_to_offset(lsb(!bits));
         };
-        bits |= 1 << loc.bit();
-        let offset = loc.in_sector().byte() as usize;
-        self.io.acquire().await.wrap().write(loc.sector(), offset, &[bits; 1]).await?;
+        bits |= 1 << locator.bit();
+        let offset = locator.in_sector().byte() as usize;
+        self.io.acquire().await.wrap().write(locator.sector(), offset, &[bits; 1]).await?;
         self.num_inuse += 1;
-        self.cursor = loc.cluster + (bits == 0xFF) as u32;
+        self.cursor = locator.cluster + (bits == 0xFF) as u32;
         self.ensure_percent_inuse().await?;
-        trace!("Allocated cluster {}", loc.cluster);
-        Ok(Clusters { base: loc.cluster, size: 1, bits: 0 })
+        trace!("Allocated cluster {}", locator.cluster);
+        Ok(Clusters { base: locator.cluster, size: 1, bits: 0 })
     }
 
     async fn release_one(&mut self, locator: Locator) -> Result<(), Error<E>> {
@@ -164,13 +166,13 @@ where
         while locator.cluster.valid() {
             self.release_one(locator).await?;
             self.num_inuse -= 1;
-            let sector_id = match self.fat.fat_sector_id(locator.cluster) {
+            let sector = match self.fat.fat_sector(locator.cluster) {
                 Some(id) => id,
                 None => return Ok(()),
             };
             let mut io = self.io.acquire().await.wrap();
-            let sector = io.read(sector_id).await?;
-            let entry = match self.fat.next_cluster_id(&sector, locator.cluster) {
+            let blocks = io.read(sector).await?;
+            let entry = match self.fat.next_cluster_id(&blocks, locator.cluster) {
                 Ok(entry) => entry,
                 Err(value) => {
                     warn!("Invalid next entry {:X} for cluster id {}", value, locator);

--- a/src/cluster_heap/directory/entry_iter.rs
+++ b/src/cluster_heap/directory/entry_iter.rs
@@ -1,5 +1,4 @@
 use core::fmt::Debug;
-use core::mem;
 use core::ops::Deref;
 
 use crate::cluster_heap::meta::FileSectors;
@@ -7,28 +6,27 @@ use crate::error::Error;
 use crate::fs::SectorIndex;
 use crate::io::{self, Block, Wrap};
 use crate::region::data::entry_type::RawEntryType;
-use crate::region::data::entryset::{ENTRY_SIZE, RawEntry};
+use crate::region::data::entryset::{ENTRY_SIZE, RawEntry, entries_from_blocks};
 use crate::sync::Share;
 
-pub struct EntryIter<'a, IO> {
+pub struct EntryIter<'a, B, IO> {
     sectors: &'a mut FileSectors<IO>,
-    entries: &'a [[RawEntry; 16]],
+    blocks: B,
     pub sector_index: SectorIndex,
     pub index: u8,
 }
 
 #[cfg_attr(not(feature = "async"), maybe_async::must_be_sync)]
-impl<'a, B: Deref<Target = [Block]>, E: Debug, IO, S: Share<Target = IO>> EntryIter<'a, S>
+impl<'a, B: Deref<Target = [Block]>, E: Debug, IO, S: Share<Target = IO>> EntryIter<'a, B, S>
 where
     IO: io::IO<Block<'static> = B, Error = E>,
 {
-    pub async fn new(sectors: &'a mut FileSectors<S>) -> Result<EntryIter<'a, S>, Error<E>> {
+    pub async fn new(sectors: &'a mut FileSectors<S>) -> Result<EntryIter<'a, B, S>, Error<E>> {
         let sector_index = sectors.sector_index;
         let mut io = sectors.io.acquire().await.wrap();
-        let sector = io.read(sector_index.id(&sectors.fs)).await?;
-        let entries = unsafe { mem::transmute(&*sector) };
+        let blocks = io.read(sector_index.sector(&sectors.fs)).await?;
         drop(io);
-        Ok(Self { sectors, entries, sector_index, index: u8::MAX })
+        Ok(Self { sectors, blocks, sector_index, index: u8::MAX })
     }
 
     pub async fn skip(&mut self, num_entries: u8) -> Result<(), Error<E>> {
@@ -38,16 +36,15 @@ where
             self.index -= (sector_size / ENTRY_SIZE) as u8;
             self.sector_index = self.sectors.next(self.sector_index).await?;
             let mut io = self.sectors.io.acquire().await.wrap();
-            let sector = io.read(self.sector_index.id(&self.sectors.fs)).await?;
-            self.entries = unsafe { mem::transmute(&*sector) };
+            self.blocks = io.read(self.sector_index.sector(&self.sectors.fs)).await?;
         }
         Ok(())
     }
 
-    pub async fn next(&mut self) -> Result<Option<&'a RawEntry>, Error<E>> {
+    pub async fn next(&mut self) -> Result<Option<RawEntry>, Error<E>> {
         self.skip(1).await?;
-        let index = self.index as usize;
-        let entry = &self.entries[index / 16][index % 16];
+        let entries = entries_from_blocks(&self.blocks);
+        let entry = entries[self.index as usize];
         let entry_type: RawEntryType = entry[0].into();
         Ok(if !entry_type.is_end_of_directory() { Some(entry) } else { None })
     }

--- a/src/cluster_heap/directory/mod.rs
+++ b/src/cluster_heap/directory/mod.rs
@@ -19,7 +19,7 @@ use crate::io::{self, Block, Wrap};
 use crate::region::data::entry_type::{EntryType, RawEntryType};
 use crate::region::data::entryset::primary::{DateTime, FileDirectory, name_hash};
 use crate::region::data::entryset::secondary::{Filename, Secondary, StreamExtension};
-use crate::region::data::entryset::{ENTRY_SIZE, RawEntry, checksum};
+use crate::region::data::entryset::{ENTRY_SIZE, checksum, entries_from_blocks};
 use crate::sync::Share;
 use crate::types::ClusterID;
 use crate::upcase_table::UpcaseTable;
@@ -66,14 +66,14 @@ where
                     return Err(DataError::Metadata.into());
                 }
             };
-            file_directory = unsafe { mem::transmute(*entry) };
+            file_directory = unsafe { mem::transmute(entry) };
             if file_directory.secondary_count < 2 {
                 return Err(DataError::Metadata.into());
             }
             let entryset_sector_index = iter.sector_index;
             let entryset_index = iter.index;
             let entry = iter.next().await?.unwrap();
-            stream_extension = unsafe { mem::transmute(*entry) };
+            stream_extension = unsafe { mem::transmute(entry) };
             if !f(&file_directory, &stream_extension) {
                 iter.skip(file_directory.secondary_count - 2).await?;
                 continue;
@@ -84,7 +84,7 @@ where
                 if cfg!(feature = "max-filename-size-30") && (i + 1) * 15 > array.len() {
                     continue;
                 }
-                let entry: &Filename = unsafe { mem::transmute(iter.next().await?.unwrap()) };
+                let entry: Filename = unsafe { mem::transmute(iter.next().await?.unwrap()) };
                 let slice = &unsafe { entry.filename.assume_init_ref() }[..];
                 array[i * 15..(i + 1) * 15].copy_from_slice(slice);
             }
@@ -197,9 +197,8 @@ where
 
         loop {
             let mut io = self.meta.sectors.io.acquire().await.wrap();
-            let sector = io.read(sector_index.id(&self.meta.sectors.fs)).await?;
-            let entries: &[[RawEntry; 16]] = unsafe { mem::transmute(&*sector) };
-            for (i, entry) in entries.iter().map(|e| e.iter()).flatten().enumerate() {
+            let blocks = io.read(sector_index.sector(&self.meta.sectors.fs)).await?;
+            for (i, entry) in entries_from_blocks(&blocks).iter().enumerate() {
                 if skip > 0 {
                     skip -= 1;
                     continue;
@@ -278,13 +277,13 @@ where
         let sum = checksum(&file_directory, &stream_extension, name);
         file_directory.set_checksum = sum.into();
 
-        let sector_id = write_entry_index.sector_index.id(&self.meta.sectors.fs);
+        let sector = write_entry_index.sector_index.sector(&self.meta.sectors.fs);
         let offset = write_entry_index.index as usize * ENTRY_SIZE;
         let bytes: &[u8; ENTRY_SIZE] = unsafe { mem::transmute(&file_directory) };
         let mut io = self.meta.sectors.io.acquire().await.wrap();
-        io.write(sector_id, offset, bytes).await?;
+        io.write(sector, offset, bytes).await?;
         let bytes: &[u8; ENTRY_SIZE] = unsafe { mem::transmute(&stream_extension) };
-        io.write(sector_id, offset + ENTRY_SIZE, bytes).await?;
+        io.write(sector, offset + ENTRY_SIZE, bytes).await?;
 
         let mut chars = name.chars();
         let mut filename = Filename::default();
@@ -294,18 +293,18 @@ where
                 buf[i] = u16::to_le(chars.next().unwrap_or('\0') as u16)
             }
             let bytes: &[u8; ENTRY_SIZE] = unsafe { mem::transmute(&filename) };
-            io.write(sector_id, offset + index * ENTRY_SIZE, bytes).await?;
+            io.write(sector, offset + index * ENTRY_SIZE, bytes).await?;
         }
         if tail {
             let offset = offset + (num_entries as usize + 2) * ENTRY_SIZE;
-            io.write(sector_id, offset, &[0]).await?;
+            io.write(sector, offset, &[0]).await?;
         };
         // Fill free entries afterwards to avoid corrupting metadata
         if out_of_capacity {
-            let sector_id = sector_index.id(&self.meta.sectors.fs);
+            let sector = sector_index.sector(&self.meta.sectors.fs);
             let byte: u8 = RawEntryType::new(EntryType::Filename, false).into();
             for i in free_entry_index.index as usize..(sector_size / ENTRY_SIZE) {
-                io.write(sector_id, i * ENTRY_SIZE, &[byte]).await?;
+                io.write(sector, i * ENTRY_SIZE, &[byte]).await?;
             }
         }
         io.flush().await
@@ -330,29 +329,29 @@ where
         };
 
         let fs_info = self.meta.sectors.fs;
-        let mut sector_id = meta.entry_index.sector_index.id(&fs_info);
+        let mut sector = meta.entry_index.sector_index.sector(&fs_info);
         let secondary_count = meta.file_directory.secondary_count as usize;
         let last_index = meta.entry_index.index as usize + secondary_count;
         let sector_size = fs_info.sector_size() as usize;
-        let next_sector_id = match last_index * ENTRY_SIZE > sector_size {
-            true => self.meta.sectors.next(meta.entry_index.sector_index).await?.id(&fs_info),
-            false => sector_id,
+        let next_sector = match last_index * ENTRY_SIZE > sector_size {
+            true => self.meta.sectors.next(meta.entry_index.sector_index).await?.sector(&fs_info),
+            false => sector,
         };
 
         let mut offset = meta.entry_index.index as usize * ENTRY_SIZE;
         let mut io = self.meta.sectors.io.acquire().await.wrap();
-        io.write(sector_id, offset, &[EntryType::FileDirectory.into(); 1]).await?;
+        io.write(sector, offset, &[EntryType::FileDirectory.into(); 1]).await?;
         offset = (offset + ENTRY_SIZE) % sector_size;
         if offset == 0 {
-            sector_id = next_sector_id;
+            sector = next_sector;
         }
-        io.write(sector_id, offset, &[EntryType::StreamExtension.into(); 1]).await?;
+        io.write(sector, offset, &[EntryType::StreamExtension.into(); 1]).await?;
         for _ in 0..(secondary_count - 1) {
             offset = (offset + ENTRY_SIZE) % sector_size;
             if offset == 0 {
-                sector_id = next_sector_id;
+                sector = next_sector;
             }
-            io.write(sector_id, offset, &[EntryType::Filename.into(); 1]).await?;
+            io.write(sector, offset, &[EntryType::Filename.into(); 1]).await?;
         }
         drop(io);
 

--- a/src/cluster_heap/entryset.rs
+++ b/src/cluster_heap/entryset.rs
@@ -6,12 +6,11 @@ use crate::file::MAX_FILENAME_SIZE;
 use crate::fs::{self, SectorIndex};
 use crate::region::data::entryset::primary::FileDirectory;
 use crate::region::data::entryset::secondary::{Secondary, StreamExtension};
-use crate::types::SectorID;
 
 #[derive(Copy, Clone, Debug, Display, Eq, Ord, PartialEq, PartialOrd)]
-#[display("{}:{}", sector_id, index)]
+#[display("{}:{}", sector, index)]
 pub(crate) struct EntryID {
-    pub sector_id: SectorID,
+    pub sector: u64,
     pub index: u8, // Max sector size / enty size = 4096 / 32 = 128
 }
 
@@ -69,7 +68,7 @@ impl EntrySet {
     }
 
     pub(crate) fn id(&self, fs: &fs::Meta) -> EntryID {
-        let sector_id = self.entry_index.sector_index.id(fs);
-        EntryID { sector_id, index: self.entry_index.index }
+        let sector = self.entry_index.sector_index.sector(fs);
+        EntryID { sector, index: self.entry_index.index }
     }
 }

--- a/src/cluster_heap/file.rs
+++ b/src/cluster_heap/file.rs
@@ -96,11 +96,11 @@ where
         }
         let sector_size = self.meta.sectors.fs.sector_size() as usize;
         let offset = self.cursor as usize % sector_size;
-        let sector_id = self.sector_index.id(&self.meta.sectors.fs);
+        let sector = self.sector_index.sector(&self.meta.sectors.fs);
         let sector_remain = sector_size - offset;
         let mut io = self.meta.sectors.io.acquire().await.wrap();
-        let sector = io.read(sector_id).await?;
-        let bytes = crate::io::flatten(&*sector);
+        let blocks = io.read(sector).await?;
+        let bytes = crate::io::flatten(&blocks);
         if buf.len() <= sector_remain {
             buf.copy_from_slice(&bytes[offset..offset + buf.len()]);
             drop(io);
@@ -116,16 +116,16 @@ where
         self.sector_index = self.meta.sectors.next(self.sector_index).await?;
         for _ in 0..remain.len() / sector_size {
             let mut io = self.meta.sectors.io.acquire().await.wrap();
-            let sector = io.read(sector_id).await?;
-            let bytes = crate::io::flatten(&*sector);
+            let blocks = io.read(sector).await?;
+            let bytes = crate::io::flatten(&blocks);
             remain[..sector_size].copy_from_slice(bytes);
             drop(io);
             self.sector_index = self.meta.sectors.next(self.sector_index).await?;
             remain = &mut remain[sector_size..];
         }
         let mut io = self.meta.sectors.io.acquire().await.wrap();
-        let sector = io.read(sector_id).await?;
-        let bytes = crate::io::flatten(&*sector);
+        let blocks = io.read(sector).await?;
+        let bytes = crate::io::flatten(&blocks);
         remain.copy_from_slice(&bytes[..remain.len()]);
         self.cursor += buf.len() as u64;
         Ok(buf.len())
@@ -150,9 +150,9 @@ where
             let length = core::cmp::min(bytes.len(), sector_remain);
             let chunk = &bytes[..length];
             trace!("Write to sector-ref {}", self.sector_index);
-            let sector_id = self.sector_index.id(&self.meta.sectors.fs);
+            let sector = self.sector_index.sector(&self.meta.sectors.fs);
             let mut io = self.meta.sectors.io.acquire().await.wrap();
-            io.write(sector_id, self.cursor as usize % sector_size, chunk).await?;
+            io.write(sector, self.cursor as usize % sector_size, chunk).await?;
             drop(io);
             self.cursor += length as u64;
             self.size = core::cmp::max(self.cursor, self.size);
@@ -167,10 +167,10 @@ where
             capacity = self.meta.sectors.metadata.capacity();
         }
         trace!("Write to sector-ref {}", self.sector_index);
-        let sector_id = self.sector_index.id(&self.meta.sectors.fs);
+        let sector = self.sector_index.sector(&self.meta.sectors.fs);
         let length = core::cmp::min(bytes.len(), sector_size);
         let chunk = &bytes[..length];
-        self.meta.sectors.io.acquire().await.wrap().write(sector_id, 0, chunk).await?;
+        self.meta.sectors.io.acquire().await.wrap().write(sector, 0, chunk).await?;
         self.cursor += length as u64;
         self.size = core::cmp::max(self.cursor, self.size);
         if length == sector_size && self.cursor < capacity {

--- a/src/cluster_heap/meta.rs
+++ b/src/cluster_heap/meta.rs
@@ -14,7 +14,7 @@ use crate::region::data::entryset::primary::DateTime;
 use crate::region::data::entryset::{ENTRY_SIZE, RawEntry};
 use crate::region::fat::Entry;
 use crate::sync::{Share, Shared};
-use crate::types::{ClusterID, SectorID};
+use crate::types::ClusterID;
 
 struct Locator {
     pub fat: fat::Meta,
@@ -26,8 +26,8 @@ impl Locator {
         self.cluster = self.cluster + 1u32;
     }
 
-    fn sector(&self) -> SectorID {
-        self.fat.fat_sector_id(self.cluster).unwrap()
+    fn sector(&self) -> u64 {
+        self.fat.fat_sector(self.cluster).unwrap()
     }
 }
 
@@ -46,7 +46,7 @@ where
 {
     pub async fn next(&mut self, sector_index: SectorIndex) -> Result<SectorIndex, Error<E>> {
         let fat_chain = self.metadata.stream_extension.general_secondary_flags.fat_chain();
-        if sector_index.sector != self.fs.sectors_per_cluster() {
+        if sector_index.index != self.fs.sectors_per_cluster() {
             return Ok(sector_index.next(self.fs.sectors_per_cluster()));
         }
         if !fat_chain {
@@ -58,11 +58,10 @@ where
             return Ok(sector_index.next(self.fs.sectors_per_cluster()));
         }
         let cluster_id = sector_index.cluster;
-        let option = self.fat.fat_sector_id(cluster_id);
-        let sector_id = option.ok_or(Error::Data(DataError::FATChain))?;
+        let sector = self.fat.fat_sector(cluster_id).ok_or(Error::Data(DataError::FATChain))?;
         let mut io = self.io.acquire().await.wrap();
-        let block = io.read(sector_id).await?;
-        match self.fat.next_cluster_id(&block, sector_index.cluster) {
+        let blocks = io.read(sector).await?;
+        match self.fat.next_cluster_id(&blocks, sector_index.cluster) {
             Ok(Entry::Next(cluster_id)) => Ok(SectorIndex::new(cluster_id, 0)),
             Ok(Entry::Last) => Err(OperationError::EOF.into()),
             _ => Err(DataError::FATChain.into()),
@@ -79,8 +78,8 @@ pub struct MetaFileDirectory<IO> {
 impl<IO> MetaFileDirectory<IO> {
     pub(crate) fn id(&self) -> EntryID {
         let entry_index = &self.sectors.metadata.entry_index;
-        let sector_id = entry_index.sector_index.id(&self.sectors.fs);
-        EntryID { sector_id, index: entry_index.index }
+        let sector = entry_index.sector_index.sector(&self.sectors.fs);
+        EntryID { sector, index: entry_index.index }
     }
 }
 
@@ -133,14 +132,14 @@ where
             let mut last = last;
             let mut iter = allocation;
             while let Some(cluster) = iter.next() {
-                let sector_id = self.sectors.fat.fat_sector_id(last).unwrap();
+                let sector = self.sectors.fat.fat_sector(last).unwrap();
                 let bytes = u32::to_le_bytes(cluster.into());
-                io.write(sector_id, self.sectors.fat.offset(last), &bytes).await?;
+                io.write(sector, self.sectors.fat.offset(last), &bytes).await?;
                 last = cluster;
             }
-            let sector_id = self.sectors.fat.fat_sector_id(last).unwrap();
+            let sector = self.sectors.fat.fat_sector(last).unwrap();
             let bytes = u32::to_ne_bytes(Entry::Last.into());
-            io.write(sector_id, self.sectors.fat.offset(last), &bytes).await?;
+            io.write(sector, self.sectors.fat.offset(last), &bytes).await?;
         }
         if metadata.file_directory.file_attributes().directory() > 0 {
             let length = metadata.length() + cluster_size;
@@ -165,18 +164,18 @@ where
         }
         if metadata.dirty {
             trace!("Flush dirty metadata");
-            let mut sector_id = metadata.entry_index.sector_index.id(&self.sectors.fs);
+            let mut sector = metadata.entry_index.sector_index.sector(&self.sectors.fs);
             let bytes: &RawEntry = unsafe { transmute(&metadata.file_directory) };
             let offset = metadata.entry_index.index as usize * ENTRY_SIZE;
             let mut io = self.sectors.io.acquire().await;
-            io.write(sector_id, offset, &bytes[..]).await.map_err(|e| Error::IO(e))?;
+            io.write(sector, offset, &bytes[..]).await.map_err(|e| Error::IO(e))?;
             let mut offset = (metadata.entry_index.index as usize + 1) * ENTRY_SIZE;
             if offset == self.sectors.fs.sector_size() as usize {
                 offset = 0;
-                sector_id += 1u32;
+                sector += 1;
             }
             let bytes: &RawEntry = unsafe { transmute(&metadata.stream_extension) };
-            io.write(sector_id, offset, &bytes[..]).await.map_err(|e| Error::IO(e))?;
+            io.write(sector, offset, &bytes[..]).await.map_err(|e| Error::IO(e))?;
             io.flush().await.map_err(|e| Error::IO(e))?;
             metadata.dirty = false;
         }

--- a/src/cluster_heap/root.rs
+++ b/src/cluster_heap/root.rs
@@ -23,7 +23,7 @@ use crate::io::{self, Block, Wrap};
 use crate::region;
 use crate::region::data::entry_type::{EntryType, RawEntryType};
 use crate::sync::{Share, Shared};
-use crate::types::{ClusterID, SectorID};
+use crate::types::ClusterID;
 
 macro_rules! all_is_some {
     ($($option:expr),+) => ($($option.is_some()) &&+);
@@ -54,17 +54,13 @@ where
             let raw_type = RawEntryType::from(entry[0]);
             match raw_type.entry_type() {
                 Ok(EntryType::AllocationBitmap) => {
-                    let bitmap: &region::data::AllocationBitmap = unsafe { mem::transmute(entry) };
-                    allocation_bitmap = Some(*bitmap)
+                    allocation_bitmap = Some(unsafe { mem::transmute(entry) })
                 }
                 Ok(EntryType::VolumnLabel) => {
-                    let label: &region::data::VolumnLabel = unsafe { mem::transmute(entry) };
-                    volumn_label = Some((*label).into())
+                    let label: region::data::VolumnLabel = unsafe { mem::transmute(entry) };
+                    volumn_label = Some(label.into())
                 }
-                Ok(EntryType::UpcaseTable) => {
-                    let table: &region::data::UpcaseTable = unsafe { mem::transmute(entry) };
-                    upcase_table = Some(*table)
-                }
+                Ok(EntryType::UpcaseTable) => upcase_table = Some(unsafe { mem::transmute(entry) }),
                 _ if raw_type.is_end_of_directory() => break,
                 _ => continue,
             };
@@ -78,7 +74,7 @@ where
             let region = allocation_bitmap.ok_or(DataError::AllocationBitmapMissing)?;
             let first_cluster = region.first_cluster.to_ne();
             let sector_offset = (first_cluster - 2) * fs.sectors_per_cluster();
-            let base = SectorID::from((fs.heap_offset + sector_offset) as u64);
+            let base = (fs.heap_offset + sector_offset) as u64;
             let size = region.data_length.to_ne() as u32;
             debug!("Allocation bitmap found at cluster {} length {}", first_cluster, size);
             let meta = super::allocation_bitmap::Meta::new(io.clone(), size).await?;
@@ -92,7 +88,7 @@ where
         let length = upcase_table.data_length.to_ne();
         debug!("Upcase table found at cluster {} length {}", cluster_id, length);
         let mut io = io.acquire().await.wrap();
-        let sector = io.read(SectorIndex::new(cluster_id.into(), 0).id(&fs)).await?;
+        let sector = io.read(SectorIndex::new(cluster_id.into(), 0).sector(&fs)).await?;
         let array: &[LE<u16>; 128] = unsafe { mem::transmute(&sector[0]) };
         let options = FileOptions::default();
         let upcase_table_data = Rc::new((*array).into());
@@ -109,7 +105,7 @@ where
         let mut checksum = region::data::Checksum::default();
         let first_cluster = self.upcase_table.first_cluster.to_ne();
         let fs = &self.meta.sectors.fs;
-        let first_sector = SectorIndex::new(first_cluster.into(), 0).id(&fs);
+        let first_sector = SectorIndex::new(first_cluster.into(), 0).sector(&fs);
         let data_length = self.upcase_table.data_length.to_ne();
         let sector_size = fs.sector_size();
         let num_sectors = data_length / sector_size as u64;

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -1,6 +1,6 @@
 use crate::io::Block;
 use crate::region::fat::Entry;
-use crate::types::{ClusterID, SectorID};
+use crate::types::ClusterID;
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct Meta {
@@ -19,13 +19,13 @@ impl Meta {
         1 << self.sector_size_shift
     }
 
-    pub fn fat_sector_id(&self, cluster_id: ClusterID) -> Option<SectorID> {
+    pub fn fat_sector(&self, cluster_id: ClusterID) -> Option<u64> {
         let index: u32 = cluster_id.into();
         let sector_index = index / (self.sector_size() / 4);
         if sector_index >= self.length {
             return None;
         }
-        Some(SectorID::from((self.offset + sector_index) as u64))
+        Some((self.offset + sector_index) as u64)
     }
 
     pub fn offset(&self, cluster_id: ClusterID) -> usize {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,6 @@
 use derive_more::Display;
 
-use crate::types::{ClusterID, SectorID};
+use crate::types::ClusterID;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Meta {
@@ -28,30 +28,30 @@ impl Meta {
 }
 
 #[derive(Copy, Clone, Debug, Default, Display)]
-#[display("{}:{}", cluster, sector)]
+#[display("{}:{}", cluster, index)]
 pub struct SectorIndex {
     pub cluster: ClusterID,
-    pub sector: u32,
+    pub index: u32,
 }
 
 impl SectorIndex {
-    pub fn id(&self, meta: &Meta) -> SectorID {
+    pub fn sector(&self, meta: &Meta) -> u64 {
         let index: u32 = self.cluster.into();
         if index == 0 {
-            return SectorID::BOOT; // root directory metadata
+            return crate::BOOT_SECTOR; // root directory metadata
         }
         let num_sectors = (index as u64 - 2) * meta.sectors_per_cluster() as u64;
-        SectorID::from(meta.heap_offset as u64 + num_sectors + self.sector as u64)
+        meta.heap_offset as u64 + num_sectors + self.index as u64
     }
 
-    pub fn new(cluster: ClusterID, sector: u32) -> Self {
-        Self { cluster, sector }
+    pub fn new(cluster: ClusterID, index: u32) -> Self {
+        Self { cluster, index }
     }
 
     pub fn next(&self, sectors_per_cluster: u32) -> Self {
-        if self.sector + 1 > sectors_per_cluster {
-            return Self { cluster: self.cluster + 1u32, sector: 0, ..*self };
+        if self.index + 1 > sectors_per_cluster {
+            return Self { cluster: self.cluster + 1u32, index: 0, ..*self };
         }
-        Self { sector: self.sector + 1, ..*self }
+        Self { index: self.index + 1, ..*self }
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -5,13 +5,12 @@ use core::fmt::Debug;
 use core::ops::{Deref, DerefMut};
 
 use crate::error::Error;
-use crate::types::SectorID;
 
 pub const BLOCK_SIZE: usize = 512;
 pub type Block = [u8; BLOCK_SIZE];
 
-pub(crate) fn flatten(sector: &[Block]) -> &[u8] {
-    unsafe { core::slice::from_raw_parts(&sector[0][0], sector.len() * 512) }
+pub(crate) fn flatten(blocks: &[Block]) -> &[u8] {
+    unsafe { core::slice::from_raw_parts(&blocks[0][0], blocks.len() * BLOCK_SIZE) }
 }
 
 pub trait ErrorType {
@@ -21,7 +20,7 @@ pub trait ErrorType {
 #[cfg(not(feature = "async"))]
 pub trait Write: ErrorType {
     /// Caller guarantees bytes.len() <= SECTOR_SIZE - offset
-    fn write(&mut self, id: SectorID, offset: usize, data: &[u8]) -> Result<(), Self::Error>;
+    fn write(&mut self, sector: u64, offset: usize, data: &[u8]) -> Result<(), Self::Error>;
 
     fn flush(&mut self) -> Result<(), Self::Error>;
 }
@@ -30,7 +29,7 @@ pub trait Write: ErrorType {
 pub trait Write: ErrorType {
     /// Caller guarantees bytes.len() <= SECTOR_SIZE - offset
     fn write(
-        &mut self, id: SectorID, offset: usize, data: &[u8],
+        &mut self, sector: u64, offset: usize, data: &[u8],
     ) -> impl Future<Output = Result<(), Self::Error>>;
 
     fn flush(&mut self) -> impl Future<Output = Result<(), Self::Error>>;
@@ -40,11 +39,11 @@ pub trait Read: ErrorType {
     type Block<'a>: Deref<Target = [Block]> + 'a;
 
     #[cfg(not(feature = "async"))]
-    fn read<'a>(&mut self, id: SectorID) -> Result<Self::Block<'a>, Self::Error>;
+    fn read<'a>(&mut self, sector: u64) -> Result<Self::Block<'a>, Self::Error>;
 
     #[cfg(feature = "async")]
     fn read<'a>(
-        &mut self, id: SectorID,
+        &mut self, sector: u64,
     ) -> impl Future<Output = Result<Self::Block<'a>, Self::Error>>;
 }
 
@@ -65,13 +64,12 @@ where
         self.0.set_sector_size_shift(shift).map_err(|e| Error::IO(e))
     }
 
-    pub async fn read(&mut self, sector: SectorID) -> Result<B, Error<E>> {
+    pub async fn read(&mut self, sector: u64) -> Result<B, Error<E>> {
         self.0.read(sector).await.map_err(|e| Error::IO(e))
     }
 
-    pub async fn write(&mut self, id: SectorID, idx: usize, data: &[u8]) -> Result<(), Error<E>> {
-        let result = self.0.write(id, idx, data).await;
-        result.map_err(|e| Error::IO(e))
+    pub async fn write(&mut self, sector: u64, offset: usize, data: &[u8]) -> Result<(), Error<E>> {
+        self.0.write(sector, offset, data).await.map_err(|e| Error::IO(e))
     }
 
     pub async fn flush(&mut self) -> Result<(), Error<E>> {

--- a/src/io/std.rs
+++ b/src/io/std.rs
@@ -16,7 +16,6 @@ use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 use super::{BLOCK_SIZE, Block};
-use crate::types::SectorID;
 
 #[derive(Debug)]
 pub struct FileIO {
@@ -44,10 +43,9 @@ impl super::ErrorType for FileIO {
 
 #[cfg_attr(not(feature = "async"), maybe_async::must_be_sync)]
 impl super::Write for FileIO {
-    async fn write(&mut self, sector: SectorID, offset: usize, buf: &[u8]) -> Result<(), Error> {
+    async fn write(&mut self, sector: u64, offset: usize, buf: &[u8]) -> Result<(), Error> {
         let sector_size = 1 << self.sector_size_shift;
-        let seek = SeekFrom::Start(u64::from(sector) * sector_size + offset as u64);
-        self.file.seek(seek).await?;
+        self.file.seek(SeekFrom::Start(sector * sector_size + offset as u64)).await?;
         self.file.write_all(buf).await.map(|_| ())
     }
 
@@ -60,9 +58,9 @@ impl super::Write for FileIO {
 impl super::Read for FileIO {
     type Block<'a> = heapless::Vec<Block, 8>;
 
-    async fn read<'a>(&mut self, sector: SectorID) -> Result<Self::Block<'a>, Self::Error> {
+    async fn read<'a>(&mut self, sector: u64) -> Result<Self::Block<'a>, Self::Error> {
         let sector_size: usize = 1 << self.sector_size_shift;
-        let seek = SeekFrom::Start(u64::from(sector) * sector_size as u64);
+        let seek = SeekFrom::Start(sector * sector_size as u64);
 
         self.file.seek(seek).await?;
         let mut block = heapless::Vec::<Block, 8>::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,8 @@ use types::ClusterID;
 
 use crate::io::Block;
 use crate::sync::Share;
-use crate::types::SectorID;
+
+pub const BOOT_SECTOR: u64 = 0;
 
 pub struct ExFAT<IO> {
     io: IO,
@@ -76,7 +77,7 @@ where
 {
     pub async fn new(io: S) -> Result<Self, Error<E>> {
         let mut wrap_io = io.acquire().await.wrap();
-        let block = wrap_io.read(SectorID::BOOT).await?;
+        let block = wrap_io.read(BOOT_SECTOR).await?;
         let boot_sector: &region::boot::BootSector = unsafe { mem::transmute(&block[0]) };
         if !boot_sector.is_exfat() {
             return Err(DataError::NotExFAT.into());
@@ -106,27 +107,27 @@ where
 
     pub async fn is_dirty(&mut self) -> Result<bool, Error<E>> {
         let mut io = self.io.acquire().await.wrap();
-        let blocks = io.read(SectorID::BOOT).await?;
+        let blocks = io.read(BOOT_SECTOR).await?;
         let boot_sector: &region::boot::BootSector = unsafe { mem::transmute(&blocks[0]) };
         Ok(boot_sector.volume_flags().volume_dirty() > 0)
     }
 
     pub async fn percent_inuse(&mut self) -> Result<u8, Error<E>> {
         let mut io = self.io.acquire().await.wrap();
-        let blocks = io.read(SectorID::BOOT).await?;
+        let blocks = io.read(BOOT_SECTOR).await?;
         let boot_sector: &region::boot::BootSector = unsafe { mem::transmute(&blocks[0]) };
         Ok(boot_sector.percent_inuse)
     }
 
     pub async fn set_dirty(&mut self, dirty: bool) -> Result<(), Error<E>> {
         let mut io = self.io.acquire().await.wrap();
-        let sector = io.read(SectorID::BOOT).await?;
+        let sector = io.read(BOOT_SECTOR).await?;
         let boot_sector: &region::boot::BootSector = unsafe { mem::transmute(&sector[0]) };
         let mut volume_flags = boot_sector.volume_flags();
         volume_flags.set_volume_dirty(dirty as u16);
         let offset = offset_of!(region::boot::BootSector, volume_flags);
         let bytes: [u8; 2] = unsafe { mem::transmute(volume_flags) };
-        io.write(SectorID::BOOT, offset, &bytes).await?;
+        io.write(BOOT_SECTOR, offset, &bytes).await?;
         io.flush().await
     }
 
@@ -134,12 +135,12 @@ where
         let mut io = self.io.acquire().await.wrap();
         let mut checksum = region::boot::BootChecksum::default();
         for i in 0..=10 {
-            let sector = io.read(i.into()).await?;
+            let sector = io.read(i).await?;
             for block in sector.iter() {
                 checksum.write(i as usize, block);
             }
         }
-        let sector = io.read(11.into()).await?;
+        let sector = io.read(11).await?;
         let array: &[u32; 128] = unsafe { core::mem::transmute(&sector[0]) };
         if u32::from_le(array[0]) != checksum.sum() {
             return Err(DataError::BootChecksum.into());

--- a/src/region/data/entryset/mod.rs
+++ b/src/region/data/entryset/mod.rs
@@ -1,14 +1,21 @@
 pub(crate) mod primary;
 pub(crate) mod secondary;
 
-pub(crate) const ENTRY_SIZE: usize = 32;
-pub(crate) type RawEntry = [u8; ENTRY_SIZE];
-
 use core::mem::transmute;
 
 use super::entry_type::{EntryType, RawEntryType};
+use crate::io::{BLOCK_SIZE, Block};
 use primary::{Checksum, FileDirectory};
 use secondary::{Secondary, StreamExtension};
+
+pub(crate) const ENTRY_SIZE: usize = 32;
+pub(crate) type RawEntry = [u8; ENTRY_SIZE];
+pub(crate) const NUM_ENTRIES_IN_BLOCK: usize = BLOCK_SIZE / ENTRY_SIZE;
+
+pub(crate) fn entries_from_blocks(blocks: &[Block]) -> &[RawEntry] {
+    let slice: &[[RawEntry; NUM_ENTRIES_IN_BLOCK]] = unsafe { core::mem::transmute(blocks) };
+    unsafe { core::slice::from_raw_parts(&slice[0][0], slice.len() * NUM_ENTRIES_IN_BLOCK) }
+}
 
 pub(crate) fn checksum(fd: &FileDirectory, ext: &Secondary<StreamExtension>, name: &str) -> u16 {
     let mut checksum = Checksum::new();
@@ -20,9 +27,7 @@ pub(crate) fn checksum(fd: &FileDirectory, ext: &Secondary<StreamExtension>, nam
         checksum.write(value as u16);
     }
     let array: &[u8; ENTRY_SIZE] = unsafe { transmute(ext) };
-    for &value in array.iter() {
-        checksum.write(value as u16);
-    }
+    array.iter().for_each(|&value| checksum.write(value as u16));
     let entry_type = RawEntryType::new(EntryType::Filename, true);
     for (i, ch) in name.chars().enumerate() {
         if i % 15 == 0 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,25 +1,6 @@
 use derive_more::{Display, From, Into};
 
-#[derive(Copy, Clone, Debug, Default, Display, From, Into, Eq, Ord, PartialOrd, PartialEq)]
-pub struct SectorID(u64);
-
-impl SectorID {
-    pub(crate) const BOOT: Self = Self(0);
-}
-
-impl<I: Into<u64>> core::ops::Add<I> for SectorID {
-    type Output = Self;
-
-    fn add(self, rhs: I) -> Self {
-        Self(self.0 + rhs.into())
-    }
-}
-
-impl<I: Into<u64>> core::ops::AddAssign<I> for SectorID {
-    fn add_assign(&mut self, rhs: I) {
-        self.0 += rhs.into()
-    }
-}
+pub type Sector = u64;
 
 #[derive(Copy, Clone, Debug, Default, Display, From, Into, Eq, Ord, PartialOrd, PartialEq)]
 pub struct ClusterID(u32);
@@ -32,7 +13,11 @@ impl ClusterID {
     }
 
     pub(crate) fn offset(self) -> u32 {
-        self.0 - Self::FIRST.0
+        (self.0 - Self::FIRST.0) / 8
+    }
+
+    pub(crate) fn bit(self) -> u8 {
+        (self.0 - Self::FIRST.0) as u8 % 8
     }
 }
 


### PR DESCRIPTION
The concept of sector id make io trait unnecessarily more complex